### PR TITLE
Docker (さくらのAppRun環境)およびフロントのローディング待ち対応を行いました。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM --platform=linux/amd64 python:3.9
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
-# Dockerfile
-FROM python:3.9-slim
+FROM python:3.9
 
 WORKDIR /app
 
-# 日本語フォントとビルドに必要なパッケージをインストール
-RUN apt-get update && apt-get install -y \
-    fonts-noto-cjk \
-    gcc \
-    && rm -rf /var/lib/apt/lists/*
-
-# Python パッケージの依存関係をコピー
+# 必要なファイルをコピー
 COPY requirements.txt .
 
-# 必要なPythonパッケージをインストール
+# pipをアップグレード
+RUN pip install --upgrade pip
+
+# Pythonパッケージをインストール
 RUN pip install --no-cache-dir -r requirements.txt
 
 # アプリケーションファイルをコピー
@@ -21,48 +17,5 @@ COPY . .
 # ポート8080を公開
 EXPOSE 8080
 
-# Waitressでアプリケーションを実行（0.0.0.0で全てのインターフェースをリッスン）
+# Waitressでアプリケーションを実行
 CMD ["python", "-c", "from waitress import serve; from app import app; serve(app, host='0.0.0.0', port=8080)"]
-
-# requirements.txt
-flask==2.0.1
-waitress==2.0.0
-pillow==8.4.0
-wordcloud==1.8.1
-janome==0.4.1
-numpy==1.21.0
-
-# docker-compose.yml
-version: '3.8'
-
-services:
-  web:
-    build: .
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./templates:/app/templates
-      - ./static:/app/static
-      - ./picture:/app/picture
-      - ./fonts:/app/fonts
-      - ./poems.json:/app/poems.json
-    environment:
-      - FLASK_APP=app.py
-      - FLASK_ENV=production
-    restart: always
-
-# .dockerignore
-__pycache__
-*.pyc
-*.pyo
-*.pyd
-.Python
-env/
-venv/
-.env
-*.log
-.git
-.gitignore
-Dockerfile
-docker-compose.yml
-README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# Dockerfile
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# 日本語フォントとビルドに必要なパッケージをインストール
+RUN apt-get update && apt-get install -y \
+    fonts-noto-cjk \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python パッケージの依存関係をコピー
+COPY requirements.txt .
+
+# 必要なPythonパッケージをインストール
+RUN pip install --no-cache-dir -r requirements.txt
+
+# アプリケーションファイルをコピー
+COPY . .
+
+# ポート8080を公開
+EXPOSE 8080
+
+# Waitressでアプリケーションを実行（0.0.0.0で全てのインターフェースをリッスン）
+CMD ["python", "-c", "from waitress import serve; from app import app; serve(app, host='0.0.0.0', port=8080)"]
+
+# requirements.txt
+flask==2.0.1
+waitress==2.0.0
+pillow==8.4.0
+wordcloud==1.8.1
+janome==0.4.1
+numpy==1.21.0
+
+# docker-compose.yml
+version: '3.8'
+
+services:
+  web:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./templates:/app/templates
+      - ./static:/app/static
+      - ./picture:/app/picture
+      - ./fonts:/app/fonts
+      - ./poems.json:/app/poems.json
+    environment:
+      - FLASK_APP=app.py
+      - FLASK_ENV=production
+    restart: always
+
+# .dockerignore
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+.env
+*.log
+.git
+.gitignore
+Dockerfile
+docker-compose.yml
+README.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  web:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./templates:/app/templates
+      - ./static:/app/static
+      - ./picture:/app/picture
+      - ./fonts:/app/fonts
+      - ./poems.json:/app/poems.json
+    environment:
+      - FLASK_APP=app.py
+      - FLASK_ENV=production
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./templates:/app/templates
-      - ./static:/app/static
-      - ./picture:/app/picture
-      - ./fonts:/app/fonts
-      - ./poems.json:/app/poems.json
+      - .:/app
     environment:
       - FLASK_APP=app.py
       - FLASK_ENV=production
-    restart: always

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
-gpg==1.24.1
-packaging==24.2
-wheel @ file:///opt/homebrew/Cellar/python%403.13/3.13.1/libexec/wheel-0.45.1-py3-none-any.whl#sha256=da46333d5dcbde6e20cf7e2f8fff9e9ce76e8c94dc4afd6fb95fc4bc2745fb5e
+Flask==2.0.1
+Werkzeug==2.0.3
+waitress==2.0.0
+Pillow==8.4.0
+wordcloud==1.8.1
+janome==0.4.1
+numpy==1.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
-flask
-pandas
-openpyxl
-setuptools
-japanize-matplotlib
-janome
-wordcloud
-gunicorn
-waitress
+gpg==1.24.1
+packaging==24.2
+wheel @ file:///opt/homebrew/Cellar/python%403.13/3.13.1/libexec/wheel-0.45.1-py3-none-any.whl#sha256=da46333d5dcbde6e20cf7e2f8fff9e9ce76e8c94dc4afd6fb95fc4bc2745fb5e

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,6 @@
       text-align: center;
     }
 
-    /* タグボタンの基本デザイン */
     .tag-button {
       background-color: #fff2cc;
       border: 1px solid #f9a825;
@@ -62,13 +61,11 @@
       color: #000;
     }
 
-    /* 選択中のタグボタン */
     .tag-active {
       background-color: #f57f17;
       color: #fff;
     }
 
-    /* 場所フィルター用ボタン（基本デザイン） */
     .location-button {
       background-color: #fff2cc;
       border: 1px solid #f9a825;
@@ -84,7 +81,6 @@
       color: #000;
     }
 
-    /* 選択中の場所フィルター用ボタン */
     .location-button.active {
       background-color: #f57f17;
       color: #fff;
@@ -107,11 +103,48 @@
       margin-bottom: 10px;
       box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.1);
     }
+
+    /* ローディングオーバーレイのスタイル */
+    .loading-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.5);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1000;
+    }
+
+    .loading-content {
+      text-align: center;
+      background: white;
+      padding: 20px;
+      border-radius: 8px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    }
+
+    .spinner-border {
+      width: 3rem;
+      height: 3rem;
+    }
   </style>
 </head>
 
 <body>
   <div class="container my-5">
+    <!-- ローディングインジケータ -->
+    <div id="loading" class="loading-overlay d-none">
+      <div class="loading-content">
+        <div class="spinner-border text-warning" role="status">
+          <span class="visually-hidden">Loading...</span>
+        </div>
+        <div class="mt-2 text-warning">検索中...</div>
+      </div>
+    </div>
+
     <!-- ヘッダー -->
     <div class="text-center mb-5">
       <h1 class="header-title">Poetech太宰府</h1>
@@ -175,7 +208,7 @@
       <button type="button" class="btn search-button" onclick="displayAll()">全ての句を表示</button>
     </div>
 
-    <!-- ワードクラウド表示エリア（検索結果・件数の上に配置） -->
+    <!-- ワードクラウド表示エリア -->
     <div id="wordcloud-container" class="mt-4 text-center">
       <h3><strong>ワードクラウド</strong></h3>
       <img id="wordcloud" src="" alt="Word Cloud" style="max-width: 100%; border: 1px solid #ddd; border-radius: 8px;">
@@ -191,6 +224,15 @@
     let selectedTag = "";
     let selectedLocation = "";
 
+    // ローディング表示の制御関数
+    function showLoading() {
+      document.getElementById('loading').classList.remove('d-none');
+    }
+
+    function hideLoading() {
+      document.getElementById('loading').classList.add('d-none');
+    }
+
     document.getElementById("search-form").addEventListener("submit", (e) => {
       e.preventDefault();
       const query = document.getElementById("search-input").value;
@@ -198,8 +240,9 @@
       search(query, selectedTag, sourceValue, selectedLocation);
     });
 
-    // 検索処理（/searchエンドポイント）
+    // 検索処理
     function search(query, tag = "", source = "", location = "") {
+      showLoading(); // 検索開始時にローディング表示
       axios.post("/search", { query, tag, source, location })
         .then(response => {
           const resultsDiv = document.getElementById("results");
@@ -233,19 +276,31 @@
               resultsDiv.appendChild(div);
             });
           }
-          updateWordCloud(query, tag, source, location);
+          return updateWordCloud(query, tag, source, location);
         })
-        .catch(error => console.error("Error:", error));
+        .then(() => {
+          hideLoading(); // 全ての処理が完了したらローディング非表示
+        })
+        .catch(error => {
+          console.error("Error:", error);
+          hideLoading(); // エラー時もローディング非表示
+          // エラーメッセージを表示
+          const resultsDiv = document.getElementById("results");
+          resultsDiv.innerHTML = "<p class='text-danger'>検索中にエラーが発生しました。</p>";
+        });
     }
 
     // ワードクラウド更新処理
     function updateWordCloud(query, tag = "", source = "", location = "") {
-      axios.post("/wordcloud", { query, tag, source, location }, { responseType: 'blob' })
+      return axios.post("/wordcloud", { query, tag, source, location }, { responseType: 'blob' })
         .then(response => {
           const imageUrl = URL.createObjectURL(response.data);
           document.getElementById("wordcloud").src = imageUrl;
         })
-        .catch(error => console.error("WordCloud Error:", error));
+        .catch(error => {
+          console.error("WordCloud Error:", error);
+          throw error; // エラーを上位にスロー
+        });
     }
 
     // タグボタン押下時の処理
@@ -296,17 +351,6 @@
       selectedLocation = "";
       document.getElementById("search-input").value = "";
       document.getElementById("source-select").value = "";
-      updateTagButtonStyles();
-      updateLocationButtonStyles();
-      search("", "", "", "");
-    }
-
-    // クリアボタンの処理
-    function clearResults() {
-      document.getElementById("results").innerHTML = "";
-      document.getElementById("search-input").value = "";
-      document.getElementById("wordcloud").src = "";
-      document.getElementById("source-select").value = "";
       selectedTag = "";
       selectedLocation = "";
       updateTagButtonStyles();
@@ -314,5 +358,4 @@
     }
   </script>
 </body>
-
 </html>


### PR DESCRIPTION
リモート環境として既存のPaaSでは形態素解析のメモリ要件が足りないとのことだったので、
[AppRun β](https://manual.sakura.ad.jp/cloud/apprun/about.html)に2GiBで動かすとレスポンスタイムがいい感じになります。

また、ローディングアニメーションを作成しています。


(デプロイ予定地)
https://app-5f92b294-d806-45b4-8864-4eca7807af15.ingress.apprun.sakura.ne.jp




---

Readme.md に記載すべきなのですが、

```
docker-compose build
docker-compose up
```
でDockerコンテナを作成した後、

http://localhost:8080
でページにアクセスできます。

(本来Flask側で`host='0.0.0.0', port=8080`を設定しているのが最適なのかよくわかって無いです)


また、SakuraのAppRunにコンテナを立ち上げる前に「コンテナレジストリ」に登録する必要があります。

```
docker-compose build
docker tag {タグ名} {レジストリで登録した名前}.sakuracr.jp/web:v1.0
docker push {レジストリで登録した名前}.sakuracr.jp/web:v1.0
```

と言う感じでコンテナを更新します。
